### PR TITLE
[Need discussion] Change deserializer to read tuple from JSON.

### DIFF
--- a/derive/src/constructor.rs
+++ b/derive/src/constructor.rs
@@ -110,6 +110,7 @@ mod tests {
 				ethabi::Param {
 					name: "foo".into(),
 					kind: ethabi::ParamType::Uint(256),
+					components: vec![],
 				}
 			],
 		};

--- a/derive/src/function.rs
+++ b/derive/src/function.rs
@@ -270,12 +270,14 @@ mod tests {
 				ethabi::Param {
 					name: "foo".into(),
 					kind: ethabi::ParamType::Address,
+					components: vec![],
 				}
 			],
 			outputs: vec![
 				ethabi::Param {
 					name: "bar".into(),
 					kind: ethabi::ParamType::Uint(256),
+					components: vec![],
 				}
 			],
 			constant: false,
@@ -293,11 +295,13 @@ mod tests {
 						name: "hello".into(),
 						inputs: vec![ethabi::Param {
 							name: "foo".to_owned(),
-							kind: ethabi::ParamType::Address
+							kind: ethabi::ParamType::Address,
+							components: vec![],
 						}],
 						outputs: vec![ethabi::Param {
 							name: "bar".to_owned(),
-							kind: ethabi::ParamType::Uint(256usize)
+							kind: ethabi::ParamType::Uint(256usize),
+							components: vec![],
 						}],
 						constant: false,
 					}
@@ -347,20 +351,24 @@ mod tests {
 				ethabi::Param {
 					name: "foo".into(),
 					kind: ethabi::ParamType::FixedArray(Box::new(ethabi::ParamType::Address), 2),
+					components: vec![],
 				},
 				ethabi::Param {
 					name: "bar".into(),
 					kind: ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(256))),
+					components: vec![],
 				}
 			],
 			outputs: vec![
 				ethabi::Param {
 					name: "".into(),
 					kind: ethabi::ParamType::Uint(256),
+					components: vec![],
 				},
 				ethabi::Param {
 					name: "".into(),
 					kind: ethabi::ParamType::String,
+					components: vec![],
 				}
 			],
 			constant: false,

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -526,6 +526,8 @@ mod tests {
 		assert!(decode(&[ParamType::FixedBytes(0)], &[]).is_ok());
 		assert!(decode(&[ParamType::FixedArray(Box::new(ParamType::Bool), 0)], &[]).is_ok());
 	}
+
+	#[test]
 	fn decode_tuple() {
 		let encoded = hex!("
 			0000000000000000000000001111111111111111111111111111111111111111

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -62,9 +62,11 @@ mod tests {
 			inputs: vec![Param {
 				name: "a".to_owned(),
 				kind: ParamType::Uint(32),
+				components: vec![],
 			}, Param {
 				name: "b".to_owned(),
 				kind: ParamType::Bool,
+				components: vec![],
 			}],
 			outputs: vec![],
 			constant: false,

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -9,6 +9,9 @@ pub struct Param {
 	/// Param type.
 	#[serde(rename="type")]
 	pub kind: ParamType,
+	/// Components type for tuple.
+	#[serde(default)]
+	pub components: Vec<Param>,
 }
 
 #[cfg(test)]
@@ -28,6 +31,35 @@ mod tests {
 		assert_eq!(deserialized, Param {
 			name: "foo".to_owned(),
 			kind: ParamType::Address,
+			components: vec![] 
+		});
+	}
+
+	#[test]
+	fn param_deserialization_with_components() {
+		let s = r#"{
+			"name": "foo",
+			"type": "tuple",
+			"components": [
+				{
+					"name": "bar",
+					"type": "uint256"
+				}
+			]
+		}"#;
+
+		let deserialized: Param = serde_json::from_str(s).unwrap();
+
+		assert_eq!(deserialized, Param {
+			name: "foo".to_owned(),
+			kind: ParamType::Tuple(vec![]),
+			components: vec![
+				Param {
+					name: "bar".to_owned(),
+					kind: ParamType::Uint(256),
+					components: vec![]
+				}
+			]
 		});
 	}
 }

--- a/ethabi/src/param_type/deserialize.rs
+++ b/ethabi/src/param_type/deserialize.rs
@@ -34,7 +34,7 @@ mod tests {
 
 	#[test]
 	fn param_type_deserialization() {
-		let s = r#"["address", "bytes", "bytes32", "bool", "string", "int", "uint", "address[]", "uint[3]", "bool[][5]", "(bool,uint256)"]"#;
+		let s = r#"["address", "bytes", "bytes32", "bool", "string", "int", "uint", "address[]", "uint[3]", "bool[][5]", "(bool,uint256)", "tuple"]"#;
 		let deserialized: Vec<ParamType> = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, vec![
 			ParamType::Address,
@@ -48,6 +48,7 @@ mod tests {
 			ParamType::FixedArray(Box::new(ParamType::Uint(256)), 3),
 			ParamType::FixedArray(Box::new(ParamType::Array(Box::new(ParamType::Bool))), 5),
 			ParamType::Tuple(vec![ParamType::Bool, ParamType::Uint(256)]),
+			ParamType::Tuple(vec![]),
 		]);
 	}
 }

--- a/ethabi/src/param_type/reader.rs
+++ b/ethabi/src/param_type/reader.rs
@@ -76,6 +76,7 @@ impl Reader {
 			"string" => ParamType::String,
 			"int" => ParamType::Int(256),
 			"uint" => ParamType::Uint(256),
+			"tuple" => ParamType::Tuple(vec![]),
 			s if s.starts_with("int") => {
 				let len = try!(usize::from_str_radix(&s[3..], 10));
 				ParamType::Int(len)


### PR DESCRIPTION
Change Param data structure to load abi from json.
https://solidity.readthedocs.io/en/v0.5.10/abi-spec.html#handling-tuple-types

## Discussion point
which is better way to represent values of tuple.
1. add components field to Param struct and store vector of Params. this PR takes this way.
2. don't change any struct and just use ParamType::Tuple.
